### PR TITLE
Support Redisgreen

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,7 +4,7 @@ require 'redis'
 module Katana
     class App < Guillotine::App
       # use redis adapter with redistogo
-      uri = URI.parse(ENV["REDISTOGO_URL"] || ENV["REDIS_URL"])
+      uri = URI.parse(ENV["REDISTOGO_URL"] || ENV["REDISGREEN_URL"] || ENV["REDIS_URL"])
       REDIS = Redis.new(:host => uri.host, :port => uri.port, :password => uri.password)
       adapter = Guillotine::Adapters::RedisAdapter.new REDIS
       set :service => Guillotine::Service.new(adapter, :strip_query => false,


### PR DESCRIPTION
We use an alternative redis provider, called redisgreen because someone on our team decided they like it. For now, we just renamed our config var from `REDISGREEN_URL` to `REDISTOGO_URL`. But it would be nice to have this work out of the box.